### PR TITLE
Modified check for .exe

### DIFF
--- a/index.php
+++ b/index.php
@@ -77,7 +77,7 @@ $files = array();
 $current_path = realpath(dirname(__FILE__));
 
 //Search for .exe files in this directory
-foreach (glob(realpath(dirname(__FILE__)) . "/*.exe") as $file) {
+foreach (glob(realpath(dirname(__FILE__)) . "/Tron*.exe") as $file) {
 	$files[] = basename($file);
 } //end foreach (glob(realpath(dirname(__FILE__)) . "/*.exe") as $file) {
 


### PR DESCRIPTION
Modified the check for the .exe to include the word Tron, otherwise when symlinking is enabled in the script, the check for version will always fail when the php encounters a symlink instead of the real file.